### PR TITLE
Hotfix: 세션 카드 연사자 정보와 이미지 정렬 수정

### DIFF
--- a/components/2025-commingsoon/shared/Sessions/SessionCard.tsx
+++ b/components/2025-commingsoon/shared/Sessions/SessionCard.tsx
@@ -57,7 +57,7 @@ const SessionCard = ({
         )}
       </div>
       <div className="flex gap-12">
-        <div className="flex-1 text-purple-600 flex flex-col justify-center">
+        <div className="flex-1 text-purple-600 flex flex-col justify-center gap-1">
           <p className={clsx('font-bold', isMobile ? 'text-base' : 'text-xl')}>
             {speaker.name}
           </p>


### PR DESCRIPTION
## Key Changes

- [x] 세션 카드 연사자 정보와 이미지 정렬 수정

### Before
<img width="453" height="328" alt="image" src="https://github.com/user-attachments/assets/766d5c06-a902-4ee6-8b55-dce9a4b2783b" />

### After
<img width="452" height="327" alt="image" src="https://github.com/user-attachments/assets/0e0d3079-7476-46e2-a024-c9648a2db96f" />



## To Reviewers
